### PR TITLE
Add headtitle to wankpuffin article

### DIFF
--- a/_posts/2022-06-28-compound-curse-words.md
+++ b/_posts/2022-06-28-compound-curse-words.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "Compound pejoratives on Reddit – from <i>buttface</i> to <i>wankpuffin</i>"
+headtitle: "Compound pejoratives on Reddit – from buttface to wankpuffin"
 custom_css: "compound_curses"
 tags: [linguistics]
 thumbnail: "/assets/compound_curses/wikt_matrix.png"


### PR DESCRIPTION
Currently, the tab title includes `<i>` tags. It looks like your template has a `headtitle` field that controls the `<title>` tag without affecting the heading in the post body.